### PR TITLE
Adding Google Tag Manager Functionality

### DIFF
--- a/PortalApp/app/controller/AdvancedSearch.js
+++ b/PortalApp/app/controller/AdvancedSearch.js
@@ -34,8 +34,13 @@ Ext.define('SpWebPortal.controller.AdvancedSearch', {
 	solr: true
     },
 
+    gtmContainerId: null,
+
     init: function() {
 	//console.info("AdvancedSearch.init");
+      var settingsStore =  Ext.getStore('SettingsStore');
+      var settings = settingsStore.getAt(0);
+      this.gtmContainerId = settings.get('gtmContainerId');
 
 	this.control({
 	    'advSrch button[itemid="search-btn"]': {
@@ -152,6 +157,13 @@ Ext.define('SpWebPortal.controller.AdvancedSearch', {
 	var filterToMap = (this.getForceFitToMap() || this.getFitToMap()) && (this.mapViewIsActive() || this.getWriteToCsv());
 	if (filterStr.length == 0) {
 	    filterStr = "*";
+	}
+
+	if (this.gtmContainerId) {
+		window.dataLayer.push({
+			'event': 'search_query',
+			'searchQuery': filterStr
+		});
 	}
         this.searchFor('(' + filterStr + ')', images, maps, filterToMap);
     }

--- a/PortalApp/app/controller/Detailer.js
+++ b/PortalApp/app/controller/Detailer.js
@@ -40,6 +40,7 @@ Ext.define('SpWebPortal.controller.Detailer', {
     ignoreDetailsPageChange: true,
     stdImgSize: 500,
     collectionName: '',
+		gtmContainerId: null,
 
     init: function() {
 	//console.info("Detailer.init");
@@ -47,6 +48,7 @@ Ext.define('SpWebPortal.controller.Detailer', {
 	var settings = settingsStore.getAt(0);
 	this.stdImgSize = settings.get('imageViewSize');
 	this.collectionName = settings.get('collectionName');
+	this.gtmContainerId = settings.get('gtmContainerId');
 
 	this.control({
 	    'actioncolumn[itemid="detail-popup-ctl"]': {
@@ -375,6 +377,14 @@ Ext.define('SpWebPortal.controller.Detailer', {
 	} else {
 	    this.popupImageSrcReady(imgRecord, [isActualSize, imgWinOwner]);
 	}
+
+	if (this.gtmContainerId) {
+		window.dataLayer.push({
+			'event': 'image_detail',
+			'attachmentId': imgRecord.data.AttachmentID,
+			'attachmentTitle': imgRecord.data.Title
+		});
+	}
     },
 
     popupDetails: function(records, showMap) {
@@ -517,6 +527,14 @@ Ext.define('SpWebPortal.controller.Detailer', {
 	} else {
 	    this.detailPopWinShown(record, showMap);
 	}  
+
+	if (this.gtmContainerId) {
+		window.dataLayer.push({
+			'event': 'record_detail',
+			'catalogNumber': record.data.catalogNumber
+		});
+	}
+
     },
 
     detailPopWinShown:  function(record, showMap) {

--- a/PortalApp/app/model/SettingsModel.js
+++ b/PortalApp/app/model/SettingsModel.js
@@ -61,7 +61,8 @@ Ext.define('SpWebPortal.model.SettingsModel', {
         {name: 'clusterAverageCenter', type: 'boolean', defaultValue: true},
         {name: 'clusterMinimumClusterSize', type: 'int'},
         {name: 'clusterIgnoreHiddenMarkers', type: 'boolean', defaultValue: true},
-        {name: 'clusterStyles', type: 'json'}
+        {name: 'clusterStyles', type: 'json'},
+        {name: 'gtmContainerId', type: 'string', default: null}
    ],
 
     validations: [

--- a/PortalApp/app/view/gtm.js
+++ b/PortalApp/app/view/gtm.js
@@ -1,0 +1,19 @@
+/**
+ * Google Tag Manager
+ * 
+ * Conditionally loads GTM script into page `<head>` if `gtmContainerId` has
+ * been set in `settings.json`.
+ */
+var settingsJson = await fetch('resources/config/settings.json')
+var settings = await settingsJson.json()
+var gtmContainerId = settings[0].gtmContainerId ?? null
+
+if (gtmContainerId && document.readyState !== 'loading') {
+  var script = document.createElement('script')
+  script.innerHTML = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','${gtmContainerId}')`
+  document.head.appendChild(script)
+}

--- a/PortalApp/doc/RoughGuideToWebPortalSetup.txt
+++ b/PortalApp/doc/RoughGuideToWebPortalSetup.txt
@@ -294,6 +294,7 @@ bottomHeight: height in pixels of the bottomBranding area.
 bottomMarginLeft: CSS setting for bottomBranding content.
 bottomMarginRight: CSS setting for bottomBranding content.
 bottomWidth: width in pixels of bottomBranding content.
+gtmContainerId: Google Tag Manager container ID.
 
 
 ###################################################################

--- a/PortalApp/index.html
+++ b/PortalApp/index.html
@@ -81,6 +81,9 @@
     <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?key=AIzaSyDYHJjsVAniNFUxSZnIO6pyVBxBqRt9gmw&sensor=false"></script>
     <!--script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false"></script-->
 
+    <!-- Google Tag Manager -->
+    <script type="module" src="app/view/gtm.js"></script>
+
     <!-- Include the extjs translations -->
     <!--script type="text/javascript" src="//cdn.sencha.com/ext/gpl/4.1.1/locale/ext-lang-sv_SE.js"></script-->
 

--- a/PortalApp/resources/config/settings.json
+++ b/PortalApp/resources/config/settings.json
@@ -24,5 +24,6 @@
     "bottomHeight": null,
     "bottomMarginLeft": null,
     "bottomMarginRight": null,
-    "bottomWidth": null
+    "bottomWidth": null,
+    "gtmContainerId": null
 }]


### PR DESCRIPTION
This pull request adds support for Google Tag Manager (GTM) so a Web Portal instance may report search and click events to Google Analytics. GTM may be configured with the "gtmContainerId: Google Tag Manager container ID" in settings.json.

We wish to share this functionality with the global community of Web 