### PR TITLE
Add Image Captions on Thumbnail View

### DIFF
--- a/PortalApp/app/model/SettingsModel.js
+++ b/PortalApp/app/model/SettingsModel.js
@@ -18,54 +18,53 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 Ext.define('SpWebPortal.model.SettingsModel', {
-    extend: 'Ext.data.Model',
-    fields: [
-        {name: 'version', type: 'string', defaultValue: '2.0'}, //this is the web portal product version!
-	{name: 'portalInstance', type: 'string', defaultValue: 'spwp'},
-	{name: 'solrURL', type: 'string'},
-	{name: 'solrPageSize', type: 'int', defaultValue: 50},
-	{name: 'maxSolrPageSize', type: 'int', defaultValue: 5000},
-	{name: 'imageBaseUrl', type: 'string'},
-	{name: 'collectionName', type: 'string'},
-        {name: 'collCodeSolrFld', type: 'string'},
-	{name: 'imagePreviewSize', type: 'int', defaultValue: 200},  //when this setting is changed in settings.json, the height and width for *.tv-thumb should be set to about 7 px greater than this setting in resources/css/thumb-view.css
-	{name: 'imageViewSize', type: 'int', defaultValue: 500}, //<= 0 for actual size
-	{name: 'defInitialView', type: 'string', defaultValue: 'grid'},
-	{name: 'defMapType', type: 'string', defaultValue: 'roadmap'},
-	{name: 'backgroundURL', type: 'string', defaultValue: 'resources/images/specify128.png'},
-	{name: 'bannerURL', type: 'string'},
-	{name: 'bannerTitle', type: 'string', defaultValue: 'Specify Web Portal'},
-	{name: 'bannerHeight', type: 'int', defaultValue: 120},
-	{name: 'bannerWidth', type: 'int', defaultValue: 250},
-	{name: 'imageInfoFlds', type: 'string'},
-	{name: 'topBranding', type: 'string'},
-	{name: 'topHeight', type: 'int'},
-	{name: 'topMarginLeft', type: 'string'},
-	{name: 'topMarginRight', type: 'string'},
-	{name: 'topWidth', type: 'int'},
-	{name: 'bottomBranding', type: 'string'},
- 	{name: 'bottomHeight', type: 'int'},
-	{name: 'bottomMarginLeft', type: 'string'},
-	{name: 'bottomMarginRight', type: 'string'},
-	{name: 'bottomWidth', type: 'int'},
-	{name: 'imagePageSize', type: 'int', defaultValue: 100},
-	{name: 'allowExportToFile', type: 'int', defaultValue: 1},
-        {name: 'collections', type: 'json', defaultValue: []},
-        {name: 'doClusterFx', type: 'boolean', defaultValue: false},
-        {name: 'clusterMinPoints', type: 'int', defaultValue: 3000},
-        {name: 'clusterGridSize', type: 'int'},
-        {name: 'clusterMaxZoom', type: 'int'},
-        {name: 'clusterZoomOnClick', type: 'boolean'},
-        {name: 'clusterImagePath', type: 'string', defaultValue: 'resources/images/m'},
-        {name: 'clusterImageExtension', type: 'string'},
-        {name: 'clusterAverageCenter', type: 'boolean', defaultValue: true},
-        {name: 'clusterMinimumClusterSize', type: 'int'},
-        {name: 'clusterIgnoreHiddenMarkers', type: 'boolean', defaultValue: true},
-        {name: 'clusterStyles', type: 'json'}
-   ],
-
-    validations: [
-	{type: 'inclusion', field: 'defInitialView', list: ['grid', 'image', 'map']},
-	{type: 'inclusion', field: 'defMapType', list: ['roadmap', 'satellite', 'hybrid', 'terrain']}
-    ]
-});
+  extend: 'Ext.data.Model',
+  fields: [
+    {name: 'version', type: 'string', defaultValue: '2.0'}, //this is the web portal product version!
+    {name: 'portalInstance', type: 'string', defaultValue: 'spwp'},
+    {name: 'solrURL', type: 'string'},
+    {name: 'solrPageSize', type: 'int', defaultValue: 50},
+    {name: 'maxSolrPageSize', type: 'int', defaultValue: 5000},
+    {name: 'imageBaseUrl', type: 'string'},
+    {name: 'collectionName', type: 'string'},
+    {name: 'collCodeSolrFld', type: 'string'},
+    {name: 'imagePreviewSize', type: 'int', defaultValue: 200}, //when this setting is changed in settings.json, the height and width for *.tv-thumb should be set to about 7 px greater than this setting in resources/css/thumb-view.css
+    {name: 'imageViewSize', type: 'int', defaultValue: 500}, //<= 0 for actual size
+    {name: 'defInitialView', type: 'string', defaultValue: 'grid'},
+    {name: 'defMapType', type: 'string', defaultValue: 'roadmap'},
+    {name: 'backgroundURL', type: 'string', defaultValue: 'resources/images/specify128.png'},
+    {name: 'bannerURL', type: 'string'},
+    {name: 'bannerTitle', type: 'string', defaultValue: 'Specify Web Portal'},
+    {name: 'bannerHeight', type: 'int', defaultValue: 120},
+    {name: 'bannerWidth', type: 'int', defaultValue: 250},
+    {name: 'imageInfoFlds', type: 'string'},
+    {name: 'topBranding', type: 'string'},
+    {name: 'topHeight', type: 'int'},
+    {name: 'topMarginLeft', type: 'string'},
+    {name: 'topMarginRight', type: 'string'},
+    {name: 'topWidth', type: 'int'},
+    {name: 'bottomBranding', type: 'string'},
+    {name: 'bottomHeight', type: 'int'},
+    {name: 'bottomMarginLeft', type: 'string'},
+    {name: 'bottomMarginRight', type: 'string'},
+    {name: 'bottomWidth', type: 'int'},
+    {name: 'imagePageSize', type: 'int', defaultValue: 100},
+    {name: 'allowExportToFile', type: 'int', defaultValue: 1},
+    {name: 'collections', type: 'json', defaultValue: []},
+    {name: 'doClusterFx', type: 'boolean', defaultValue: false},
+    {name: 'clusterMinPoints', type: 'int', defaultValue: 3000},
+    {name: 'clusterGridSize', type: 'int'},
+    {name: 'clusterMaxZoom', type: 'int'},
+    {name: 'clusterZoomOnClick', type: 'boolean'},
+    {name: 'clusterImagePath', type: 'string', defaultValue: 'resources/images/m'},
+    {name: 'clusterImageExtension', type: 'string'},
+    {name: 'clusterAverageCenter', type: 'boolean', defaultValue: true},
+    {name: 'clusterMinimumClusterSize', type: 'int'},
+    {name: 'clusterIgnoreHiddenMarkers', type: 'boolean', defaultValue: true},
+    {name: 'clusterStyles', type: 'json'}
+  ],
+  validations: [
+    {type: 'inclusion', field: 'defInitialView', list: ['grid', 'image', 'map']},
+    {type: 'inclusion', field: 'defMapType', list: ['roadmap', 'satellite', 'hybrid', 'terrain']}
+  ]
+})

--- a/PortalApp/app/model/SettingsModel.js
+++ b/PortalApp/app/model/SettingsModel.js
@@ -61,7 +61,8 @@ Ext.define('SpWebPortal.model.SettingsModel', {
     {name: 'clusterAverageCenter', type: 'boolean', defaultValue: true},
     {name: 'clusterMinimumClusterSize', type: 'int'},
     {name: 'clusterIgnoreHiddenMarkers', type: 'boolean', defaultValue: true},
-    {name: 'clusterStyles', type: 'json'}
+    {name: 'clusterStyles', type: 'json'},
+		{name: 'displayImgCaption', type: 'boolean', defaultValue: false}
   ],
   validations: [
     {type: 'inclusion', field: 'defInitialView', list: ['grid', 'image', 'map']},

--- a/PortalApp/app/model/SettingsModel.js
+++ b/PortalApp/app/model/SettingsModel.js
@@ -62,7 +62,7 @@ Ext.define('SpWebPortal.model.SettingsModel', {
     {name: 'clusterMinimumClusterSize', type: 'int'},
     {name: 'clusterIgnoreHiddenMarkers', type: 'boolean', defaultValue: true},
     {name: 'clusterStyles', type: 'json'},
-		{name: 'displayImgCaption', type: 'boolean', defaultValue: false}
+    {name: 'displayImgCaption', type: 'boolean', defaultValue: false}
   ],
   validations: [
     {type: 'inclusion', field: 'defInitialView', list: ['grid', 'image', 'map']},

--- a/PortalApp/app/view/ImageSingleView.js
+++ b/PortalApp/app/view/ImageSingleView.js
@@ -87,9 +87,21 @@ Ext.define('SpWebPortal.view.ImageSingleView', {
 	this.superclass.initComponent.apply(this, arguments);
     },
 
-    getImgHtml: function() {
-	var src = this.getIsActualSize() ? this.getImageRecord().get('Src') : this.getImageRecord().get('StdSrc');
-	return  '<table class="deadcenter"> <tr><td><img src='+  src + '></td></tr></table>'; //caller will have filled-in the src.
-    }
+  getImgHtml: function () {
+    var src = this.getIsActualSize()
+      ? this.getImageRecord().get('Src')
+      : this.getImageRecord().get('StdSrc')
+
+		var displayImgCaption = Ext.getStore('SettingsStore').getAt(0).get('displayImgCaption')
+    var caption = this.getImageRecord().get('AttachedToDescr').replace('\n', '<br>')
+		var captionHtml = displayImgCaption ? '<tr><td>' + caption + '</td></tr>' : ''
+
+    return (
+      '<table class="deadcenter">' +
+      '<tr><td><img src=' + src + '></td></tr>' +
+			captionHtml +
+      '</table>'
+    ) //caller will have filled-in the src.
+  }
 
 });

--- a/PortalApp/app/view/ThumbnailView.js
+++ b/PortalApp/app/view/ThumbnailView.js
@@ -28,6 +28,7 @@ Ext.define('SpWebPortal.view.ThumbnailView', {
     extend: 'Ext.view.View',
     xtype: 'spthumbnail',
     alias: 'widget.thumbnail',
+    cls: 'tv-wrap',
 
     //localizable text...
     emptyText: 'No images to display',

--- a/PortalApp/app/view/ThumbnailView.js
+++ b/PortalApp/app/view/ThumbnailView.js
@@ -41,35 +41,40 @@ Ext.define('SpWebPortal.view.ThumbnailView', {
 	Ext.create('Ext.ux.DataView.DragSelector', {}),
 	Ext.create('Ext.ux.DataView.LabelEditor', {dataIndex: 'name'})
     ],*/
-    prepareData: function(data) {
-	Ext.apply(data, {
-	    shortName: Ext.util.Format.ellipsis(data.Title, 15)
-	});
-	return data;
-    },
+  prepareData: function (data) {
+    Ext.apply(data, {
+      shortName: Ext.util.Format.ellipsis(data.Title, 15),
+      AttachedToDescrFormatted: data.AttachedToDescr.replace('\n', '<br>')
+    })
+    return data
+  },
 
-	
+  initComponent: function () {
+		var displayImgCaption = Ext.getStore('SettingsStore').getAt(0).get('displayImgCaption')
 
-    initComponent: function() {
-	var settingsStore =  Ext.getStore('SettingsStore');
-	var settings = settingsStore.getAt(0);
-	Ext.apply(this, {
-	    tpl: [
-		'<tpl for=".">',
-		'<div class="tv-thumb-wrap" id="{AttachmentID}">',
-		//'<div class="tv-thumb"><img src="' + settings.get('imageBaseUrl') + '/{AttachmentLocation}" title="{AttachedToDescr} - {Title}"></div>',
-		//'<div class="tv-thumb"><img src="{ThumbSrc}" title="{AttachedToDescr} - {Title}"></div>',
-		'<table class="tv-thumb"><tr><td><img src="{ThumbSrc}" title="{AttachedToDescr}"></td></tr></table>',
-		//'<span class="x-editable">{shortName}</span>
-		'</div>',
-		'</tpl>',
-		'<div class="x-clear"></div>'
-	    ]
-	});
+    Ext.apply(this, {
+      tpl: new Ext.XTemplate(
+        '<tpl for=".">',
+        '<div class="tv-thumb-wrap" id="{AttachmentID}">',
+        //'<div class="tv-thumb"><img src="' + settings.get('imageBaseUrl') + '/{AttachmentLocation}" title="{AttachedToDescr} - {Title}"></div>',
+        //'<div class="tv-thumb"><img src="{ThumbSrc}" title="{AttachedToDescr} - {Title}"></div>',
+        '<table class="tv-thumb"><tr><td class="tv-cell"><img src="{ThumbSrc}" title="{AttachedToDescr}"></td></tr></table>',
+        '<tpl if="this.displayCaption()">',
+          '<table class="tv-desc"><tr><td>{AttachedToDescrFormatted}</td></tr></table>',
+        '</tpl>',
+        //'<span class="x-editable">{shortName}</span>
+        '</div>',
+        '</tpl>',
+        '<div class="x-clear"></div>',
+        {
+          displayCaption: function() {
+            return displayImgCaption
+          }
+        }
+      ),
+    })
 
-//	this.callParent(arguments);
-	this.superclass.initComponent.apply(this, arguments);
-    }
-		 
-});
-
+    //	this.callParent(arguments);
+    this.superclass.initComponent.apply(this, arguments)
+  }
+})

--- a/PortalApp/app/view/ThumbnailView.js
+++ b/PortalApp/app/view/ThumbnailView.js
@@ -44,7 +44,7 @@ Ext.define('SpWebPortal.view.ThumbnailView', {
   prepareData: function (data) {
     Ext.apply(data, {
       shortName: Ext.util.Format.ellipsis(data.Title, 15),
-      AttachedToDescrFormatted: data.AttachedToDescr.replace('\n', '<br>')
+      AttachedToDescrFormatted: data.AttachedToDescr.split('\n').join('<br>')
     })
     return data
   },

--- a/PortalApp/doc/RoughGuideToWebPortalSetup.txt
+++ b/PortalApp/doc/RoughGuideToWebPortalSetup.txt
@@ -294,6 +294,7 @@ bottomHeight: height in pixels of the bottomBranding area.
 bottomMarginLeft: CSS setting for bottomBranding content.
 bottomMarginRight: CSS setting for bottomBranding content.
 bottomWidth: width in pixels of bottomBranding content.
+displayImgCaption: when set to true, the fields (as configured in imageInfoFlds, see above) will render underneath preview views and the image detail view.
 
 
 ###################################################################

--- a/PortalApp/resources/config/settings.json
+++ b/PortalApp/resources/config/settings.json
@@ -24,5 +24,6 @@
     "bottomHeight": null,
     "bottomMarginLeft": null,
     "bottomMarginRight": null,
-    "bottomWidth": null
+    "bottomWidth": null,
+    "displayImgCaption: false"
 }]

--- a/PortalApp/resources/config/settings.json
+++ b/PortalApp/resources/config/settings.json
@@ -25,5 +25,5 @@
     "bottomMarginLeft": null,
     "bottomMarginRight": null,
     "bottomWidth": null,
-    "displayImgCaption: false"
+    "displayImgCaption": false
 }]

--- a/PortalApp/resources/css/thumb-view.css
+++ b/PortalApp/resources/css/thumb-view.css
@@ -95,3 +95,8 @@
     padding: 0.5rem 0.5rem 1rem;
     display: table-cell;
 }
+
+.tv-wrap {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 207px);
+}

--- a/PortalApp/resources/css/thumb-view.css
+++ b/PortalApp/resources/css/thumb-view.css
@@ -40,7 +40,7 @@
     float: left;
     /*margin: 4px;*/
     margin-right: 0;
-    //padding: 1px;
+    max-width: 207px;
 }
 *.tv-thumb-wrap span {
     
@@ -89,4 +89,9 @@
 }.ext-strict .ext-ie .x-tree .x-panel-bwrap{
     position:relative;
     overflow:hidden;
+}
+
+.tv-desc {
+    padding: 0.5rem 0.5rem 1rem;
+    display: table-cell;
 }

--- a/PortalApp/resources/css/thumb-view.css
+++ b/PortalApp/resources/css/thumb-view.css
@@ -94,6 +94,7 @@
 .tv-desc {
     padding: 0.5rem 0.5rem 1rem;
     display: table-cell;
+    line-height: 1.35;
 }
 
 .tv-wrap {


### PR DESCRIPTION
This pull request adds support for displaying a caption under the images in the thumbnail view.  settings.json is extended with: displayImgCaption: when set to true, the fields (as configured in imageInfoFlds, see above) will render underneath preview views and the image detail view.
